### PR TITLE
v2.0 Fixes

### DIFF
--- a/KDK/OncologyCase.json
+++ b/KDK/OncologyCase.json
@@ -402,10 +402,6 @@
                                 ]
                               }
                             ]
-                          },
-                          "name": {
-                            "type": "string",
-                            "description": "Name of active substance is required when only pharmacological class is given."
                           }
                         },
                         "if": {
@@ -424,7 +420,13 @@
                         "then": {
                           "required": [
                             "name"
-                          ]
+                          ],
+                          "properties": {
+                              "name": {
+                                "type": "string",
+                                "description": "Name of active substance is required when only pharmacological class is given."
+                            }
+                          }
                         }
                       }
                     ]

--- a/KDK/OncologyFollowUp.json
+++ b/KDK/OncologyFollowUp.json
@@ -198,10 +198,6 @@
                         ]
                       }
                     ]
-                  },
-                  "name": {
-                    "type": "string",
-                    "description": "Name of active substance is required when only pharmacological class is given."
                   }
                 },
                 "if": {
@@ -218,9 +214,13 @@
                   }
                 },
                 "then": {
-                  "required": [
-                    "name"
-                  ]
+                    "required": ["name"],
+                    "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "Name of active substance is required when only pharmacological class is given."
+                        }
+                    }
                 }
               }
             ]

--- a/KDK/OncologyPlan.json
+++ b/KDK/OncologyPlan.json
@@ -182,10 +182,6 @@
                                                 "required": ["system", "code", "version"]
                                             }
                                         ]
-                                    },
-                                    "name": {
-                                        "type": "string",
-                                        "description": "Name of active substance is required when only pharmacological class is given."
                                     }
                                 },
                                 "if": {
@@ -202,7 +198,13 @@
                                     }
                                 },
                                 "then": {
-                                    "required": ["name"]
+                                    "required": ["name"],
+                                    "properties": {
+                                        "name": {
+                                          "type": "string",
+                                          "description": "Name of active substance is required when only pharmacological class is given."
+                                        }
+                                    }
                                 }
                             }
                         ]
@@ -302,10 +304,6 @@
                                                 "required": ["system", "code", "version"]
                                             }
                                         ]
-                                    },
-                                    "name": {
-                                        "type": "string",
-                                        "description": "Name of active substance is required when only pharmacological class is given."
                                     }
                                 },
                                 "required": ["code"],
@@ -323,7 +321,13 @@
                                     }
                                 },
                                 "then": {
-                                    "required": ["name"]
+                                    "required": ["name"],
+                                    "properties": {
+                                        "name": {
+                                          "type": "string",
+                                          "description": "Name of active substance is required when only pharmacological class is given."
+                                        }
+                                    }
                                 }
                             }
                         ]

--- a/KDK/RareDiseases.json
+++ b/KDK/RareDiseases.json
@@ -1,5 +1,5 @@
 {
-  "$id": "hhttps://raw.githubusercontent.com/BfArM-MVH/MVGenomseq_KDK/main/KDK/RareDiseases.json",
+  "$id": "https://raw.githubusercontent.com/BfArM-MVH/MVGenomseq_KDK/main/KDK/RareDiseases.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Rare Diseases Data Schema",
   "type": "object",
@@ -9,19 +9,19 @@
   ],
   "properties": {
     "metaData": {
-      "$ref": "hhttps://raw.githubusercontent.com/BfArM-MVH/MVGenomseq_KDK/main/KDK/Submission.json"
+      "$ref": "https://raw.githubusercontent.com/BfArM-MVH/MVGenomseq_KDK/main/KDK/Submission.json"
     },
     "case": {
-      "$ref": "hhttps://raw.githubusercontent.com/BfArM-MVH/MVGenomseq_KDK/main/KDK/RareDiseasesCase.json"
+      "$ref": "https://raw.githubusercontent.com/BfArM-MVH/MVGenomseq_KDK/main/KDK/RareDiseasesCase.json"
     },
     "molecular": {
-      "$ref": "hhttps://raw.githubusercontent.com/BfArM-MVH/MVGenomseq_KDK/main/KDK/RareDiseasesMolecular.json"
+      "$ref": "https://raw.githubusercontent.com/BfArM-MVH/MVGenomseq_KDK/main/KDK/RareDiseasesMolecular.json"
     },
     "plan": {
-      "$ref": "hhttps://raw.githubusercontent.com/BfArM-MVH/MVGenomseq_KDK/main/KDK/RareDiseasesPlan.json"
+      "$ref": "https://raw.githubusercontent.com/BfArM-MVH/MVGenomseq_KDK/main/KDK/RareDiseasesPlan.json"
     },
     "followUp": {
-      "$ref": "hhttps://raw.githubusercontent.com/BfArM-MVH/MVGenomseq_KDK/main/KDK/RareDiseasesFollowUp.json"
+      "$ref": "https://raw.githubusercontent.com/BfArM-MVH/MVGenomseq_KDK/main/KDK/RareDiseasesFollowUp.json"
     }
   }
 }

--- a/KDK/RareDiseasesPlan.json
+++ b/KDK/RareDiseasesPlan.json
@@ -174,7 +174,7 @@
           "type": "string",
           "description": "Description of the recommended therapy only if'combination' is selected."
         },
-        "variantReferences": {
+        "variants": {
           "type": "array",
           "items": {
             "allOf": [

--- a/KDK/Submission.json
+++ b/KDK/Submission.json
@@ -53,7 +53,8 @@
               "hereditary"
             ],
             "description": "Type of disease (must be oncological or hereditary for Oncology object, rare for RareDiseasesObject)"
-          },
+          }
+        },
         "required": [
           "date",
           "type",
@@ -206,7 +207,6 @@
         "otherReason"
       ],
       "description": "Reason for the negative decision"
-    }
     }
   }
 }

--- a/KDK/Taskfile.yml
+++ b/KDK/Taskfile.yml
@@ -1,0 +1,105 @@
+# https://taskfile.dev
+
+version: "3"
+
+vars:
+  AJVOPTS: --spec=draft2020 -c ajv-formats --strict --strict-types=false
+
+tasks:
+  default:
+    desc: Show all existing tasks
+    cmds:
+      - task --list-all
+    silent: true
+
+  install:
+    desc: Install ajv and ajv-formats packages, required for linting schema
+    prompt: This command will install npm packages GLOBALLY! It will run `npm install -g ajv ajv-formats. Are you sure?`
+    cmds:
+      - npm install -g ajv ajv-formats
+
+  sub:
+    desc: Lint the Submission.json package
+    cmds:
+      - |
+        ajv compile -s Submission.json \
+        -r "data-types/*.json" \
+        {{.AJVOPTS}}
+
+  # --- Rare Diseases
+  rare:
+    desc: Lint the RareDiseases.json package
+    cmds:
+      - |
+        ajv compile -s RareDiseases.json \
+        -r Submission.json \
+        -r RareDiseasesCase.json \
+        -r RareDiseasesMolecular.json \
+        -r RareDiseasesPlan.json \
+        -r RareDiseasesFollowUp.json \
+        -r "data-types/*.json" \
+        {{.AJVOPTS}}
+
+  all-rare:
+    desc: Lint all RareDiseases subschemata individually
+    cmds:
+      - for: ['RareDiseasesCase.json', 'RareDiseasesFollowUp.json', 'RareDiseasesMolecular.json', 'RareDiseasesPlan.json' ]
+        cmd: |
+            ajv compile -s {{.ITEM}} \
+            -r "data-types/*.json" \
+            {{.AJVOPTS}}
+
+  val-with-rare:
+    desc: "Validate FILE against RareDiseases.json schema. USAGE: task val-with-rare FILE=<file.json>"
+    requires:
+      vars: [FILE]
+    cmds:
+      - |
+        ajv validate -s RareDiseases.json \
+        -r Submission.json \
+        -r RareDiseasesCase.json \
+        -r RareDiseasesMolecular.json \
+        -r RareDiseasesPlan.json \
+        -r RareDiseasesFollowUp.json \
+        -r "data-types/*.json" \
+        -d {{.FILE}} \
+        {{.AJVOPTS}}
+
+  # --- Oncology
+  onco:
+    desc: Lint the OncologyCase.json package
+    cmds:
+      - |
+        ajv compile -s Oncology.json \
+        -r Submission.json \
+        -r OncologyCase.json \
+        -r OncologyMolecular.json \
+        -r OncologyPlan.json \
+        -r OncologyFollowUp.json \
+        -r "data-types/*.json" \
+        {{.AJVOPTS}}
+
+  all-onco:
+    desc: Lint all Oncology subschemata individually.
+    cmds:
+      - for: ['OncologyCase.json', 'OncologyFollowUp.json', 'OncologyMolecular.json', 'OncologyPlan.json' ]
+        cmd: |
+            ajv compile -s {{.ITEM}} \
+            -r "data-types/*.json" \
+            {{.AJVOPTS}}
+
+  val-with-onco:
+    desc: "Validate FILE against Oncology.json schema. USAGE: task val-with-onco FILE=<file.json>"
+    requires:
+      vars: [FILE]
+    cmds:
+      - |
+        ajv validate -s Oncology.json \
+        -r Submission.json \
+        -r OncologyCase.json \
+        -r OncologyMolecular.json \
+        -r OncologyPlan.json \
+        -r OncologyFollowUp.json \
+        -r "data-types/*.json" \
+        -d {{.FILE}} \
+        {{.AJVOPTS}}

--- a/KDK/data-types/Substance.json
+++ b/KDK/data-types/Substance.json
@@ -5,7 +5,7 @@
   "type": "object",
   "properties": {
     "code": {
-      "$ref": "https://www.bfarm.de/schemas/genomde/data-types/Coding#"
+      "$ref": "https://raw.githubusercontent.com/BfArM-MVH/MVGenomseq_KDK/main/KDK/data-types/Coding.json"
     },
     "name": {
       "type": "string"


### PR DESCRIPTION
# Scope

This PR contributes two things
1. Fixes for the validity of all json schemas
2. An easy way to use the `ajv` json schema linter to (automatically) find problems in json schemas, using `taskfile`
 
# Description

### Validity
The commits in this PR are well sorted and should explain the individual contributions without further explanation.
If this is not the case, feel free to contact me!

### Commit number 0e4a50083db821b08245725ec538b7ee1ca43427
In this commit, I moved the `name` property to the `then` clause. My understanding is, that the `name` field is only required, if the `then` clause takes place i.e. it should not be provided, if the `then` case is `not` in place. **Please verify, if this is what you want to express.**

### Commit number bc40e5cf29398129189c68b3ab2d46da659bc885
This is not a technical bug, but I think you wanted to replace all instances  of `variantReferences` with `variants` and probably missed this one. **Please verify, if this is correct.**

### Json Schema Linter
The tool `ajv` is the industry standard to find issues in json schemas. It was used to find all of the issues in this PR.

To use it, just install [Taskfile](https://taskfile.dev/installation/) and `npm`.

Then you can use `task` to list all available actions.
Specifically, `task onco` and `task rare` can be used to validate all respective schemata.

In the future, it might make sense to execute these tasks automatically via a Github Action, so that the integrity of the schemas is always given. 
Please feel free to contact me, if you need help with this. I am a DevOps Engineer.