### PR TITLE
fix: correct malformed $id URI and harmonise deathDate regex

### DIFF
--- a/KDK/CHANGELOG.md
+++ b/KDK/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## [1.7.2] - 2026-03-18
+### Fixed
+- **RareDiseases**
+  - Fixed malformed `$id` URI (double `h` in `hhttps://`)
+- **RareDiseasesFollowUp**
+  - Harmonised `deathDate` YYYY-MM regex to use `[0-9]` instead of `\\d`, consistent with all other date-pattern fields
 ## [1.7.1] - 2025-09-05
 ### Added
 - **Submission**

--- a/KDK/RareDiseases.json
+++ b/KDK/RareDiseases.json
@@ -1,5 +1,5 @@
 {
-  "$id": "hhttps://raw.githubusercontent.com/BfArM-MVH/MVGenomseq_KDK/main/KDK/RareDiseases.json",
+  "$id": "https://raw.githubusercontent.com/BfArM-MVH/MVGenomseq_KDK/main/KDK/RareDiseases.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Rare Diseases Data Schema",
   "type": "object",

--- a/KDK/RareDiseasesFollowUp.json
+++ b/KDK/RareDiseasesFollowUp.json
@@ -73,7 +73,7 @@
           },
           "deathDate": {
             "type": "string",
-            "pattern": "^\\d{4}-(0[1-9]|1[0-2])$",
+            "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])$",
             "description": "Month and year of death in YYYY-MM format."
           }
         },


### PR DESCRIPTION
# Bug fix: correct malformed $id URI and harmonise deathDate regex in RareDiseases schemas                                                                                  
                                                                                                                                                                                 
  Body:                                                                                                                                                                        
  ## Summary                                                                                                                                                                     
                                                                                                                                                                               
  - **RareDiseases.json**: Fix double-`h` typo in `$id` field (`hhttps://` → `https://`).
    This malformed URI would cause `$id` resolution to fail in strict JSON Schema processors.
  - **RareDiseasesFollowUp.json**: Replace `\\d` with `[0-9]` in the `deathDate` YYYY-MM     
    regex pattern, bringing it in line with all other date-pattern fields in the codebase                                                                                        
    (`birthDate`, `symptomOnsetDate`, `zseContactDate`).                                                                                                                         
                                                                                                                                                                                 
  ## Test plan                                                                                                                                                                   
                                                                                                                                                                                 
  - [ ] Validate `RareDiseases.json` and confirm the `$id` resolves cleanly as a URI                                                                                           
  - [ ] Validate `RareDiseasesFollowUp.json` and confirm `deathDate` accepts `2024-03`                                                                                           
        and rejects `2024-13` or `2024-1`                                             
  - [ ] Confirm no other schemas are affected